### PR TITLE
feat: extract API client

### DIFF
--- a/pages/moderation.py
+++ b/pages/moderation.py
@@ -8,6 +8,8 @@ import requests  # type: ignore
 import streamlit as st
 import yaml  # type: ignore
 
+from src.musicalligator_client import MusicAlligatorClient
+
 CONFIG_PATH = Path("config.yaml")
 
 # Release statuses supported by the API
@@ -44,21 +46,6 @@ def load_config() -> Dict[str, Any]:
         with CONFIG_PATH.open("r", encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     return {}
-
-
-def build_session(token: str) -> requests.Session:
-    session = requests.Session()
-    session.headers.update(
-        {
-            "Authorization": token,
-            "Accept": "application/json, text/plain, */*",
-            "X-LANG": "RU",
-            "X-Requested-With": "XMLHttpRequest",
-            "Origin": "https://app.musicalligator.ru",
-            "Referer": "https://app.musicalligator.ru/",
-        }
-    )
-    return session
 
 
 def fetch_releases(
@@ -125,7 +112,8 @@ if not artists:
     st.error("В config.yaml нет артистов")
     st.stop()
 
-session = build_session(config["auth_token"])
+client = MusicAlligatorClient(config["auth_token"])
+session = client.session
 
 
 def load_release_list() -> None:

--- a/src/musicalligator_client.py
+++ b/src/musicalligator_client.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests  # type: ignore
+import streamlit as st
+
+BASE_URL = "https://v2api.musicalligator.com/api"
+DEFAULT_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "X-LANG": "RU",
+    "X-Requested-With": "XMLHttpRequest",
+    "Origin": "https://app.musicalligator.ru",
+    "Referer": "https://app.musicalligator.ru/",
+}
+
+
+class MusicAlligatorClient:
+    """Simple wrapper for MusicAlligator API."""
+
+    def __init__(self, token: str, base_url: str = BASE_URL) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": token, **DEFAULT_HEADERS})
+
+    def _url(self, path: str) -> str:
+        return (
+            path if path.startswith("http") else f"{self.base_url}/{path.lstrip('/')}"
+        )
+
+    def get(self, path: str, **kwargs: Any) -> requests.Response:
+        try:
+            return self.session.get(self._url(path), **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            st.toast(f"Ошибка запроса GET {path}: {exc}")
+            raise
+
+    def post(self, path: str, **kwargs: Any) -> requests.Response:
+        try:
+            return self.session.post(self._url(path), **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            st.toast(f"Ошибка запроса POST {path}: {exc}")
+            raise
+
+    def put(self, path: str, **kwargs: Any) -> requests.Response:
+        try:
+            return self.session.put(self._url(path), **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            st.toast(f"Ошибка запроса PUT {path}: {exc}")
+            raise
+
+    def clone_session(self) -> requests.Session:
+        """Return a new session with copied headers."""
+        sess = requests.Session()
+        sess.headers.update(self.session.headers)
+        return sess

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from src.musicalligator_client import DEFAULT_HEADERS, MusicAlligatorClient
+
+
+def test_session_headers() -> None:
+    client = MusicAlligatorClient("token")
+    for k, v in DEFAULT_HEADERS.items():
+        assert client.session.headers.get(k) == v
+    assert client.session.headers.get("Authorization") == "token"
+
+
+def test_url_helper() -> None:
+    client = MusicAlligatorClient("token")
+    assert client._url("/path") == "https://v2api.musicalligator.com/api/path"
+    assert client._url("http://example.com") == "http://example.com"


### PR DESCRIPTION
## Summary
- add MusicAlligatorClient wrapper
- update app.py to use the client
- refactor moderation page to reuse the client
- add basic tests

## Testing
- `pip install -r requirements.txt`
- `python -m streamlit run app.py --server.headless true`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686fafdd7294832984aa3bdb8d155a74